### PR TITLE
Feat: Add pagination functionality for chat history #34

### DIFF
--- a/frontend/src/components/ChatInterface/ChatHistory.jsx
+++ b/frontend/src/components/ChatInterface/ChatHistory.jsx
@@ -1,17 +1,62 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { XMarkIcon, ChatBubbleLeftIcon } from '@heroicons/react/24/outline';
 
-const ChatHistory = ({ historyMessages, loadSessionChat, setShowHistory }) => {
+const ChatHistory = ({ 
+  historyMessages, 
+  loadSessionChat, 
+  setShowHistory,
+  loadMoreHistory,
+  isLoadingHistory,
+  hasMoreHistory 
+}) => {
+  const containerRef = useRef(null);
+  const [isNearBottom, setIsNearBottom] = useState(false);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleScroll = () => {
+      const { scrollTop, scrollHeight, clientHeight } = container;
+      // 確認是否在底部附近
+      const nearBottom = scrollHeight - scrollTop - clientHeight < 100;
+      
+      // 只有當狀態改變時才觸發載入更多
+      if (nearBottom !== isNearBottom) {
+        setIsNearBottom(nearBottom);
+        
+        // 只有當處於底部附近、有更多歷史記錄且不在載入狀態時才載入更多
+        if (nearBottom && hasMoreHistory && !isLoadingHistory) {
+          loadMoreHistory();
+        }
+      }
+    };
+
+    container.addEventListener('scroll', handleScroll);
+    return () => container.removeEventListener('scroll', handleScroll);
+  }, [loadMoreHistory, hasMoreHistory, isLoadingHistory, isNearBottom]);
 
   return (
-    <div className="fixed right-0 top-0 h-full w-80 bg-white shadow-lg z-10 p-4 overflow-y-auto">
-      <div className="flex justify-between items-center mb-4">
-        <h2 className="text-xl font-bold">聊天記錄</h2>
-        <button onClick={() => setShowHistory(false)}>
-          <XMarkIcon className="h-6 w-6" />
-        </button>
+    <div className="fixed right-0 top-0 h-full w-80 bg-white shadow-lg z-10 flex flex-col">
+      <div className="p-4 border-b">
+        <div className="flex justify-between items-center">
+          <h2 className="text-xl font-bold">聊天記錄</h2>
+          <button onClick={() => setShowHistory(false)}>
+            <XMarkIcon className="h-6 w-6" />
+          </button>
+        </div>
       </div>
-      <div className="space-y-4">
+      
+      <div 
+        ref={containerRef}
+        className="flex-1 overflow-y-auto p-4 space-y-4"
+      >
+        {historyMessages.length === 0 && !isLoadingHistory && (
+          <div className="text-center text-gray-500 py-8">
+            沒有聊天記錄
+          </div>
+        )}
+
         {historyMessages.map((session) => (
           <div
             key={session.sessionId}
@@ -19,7 +64,7 @@ const ChatHistory = ({ historyMessages, loadSessionChat, setShowHistory }) => {
             onClick={() => loadSessionChat(session.sessionId)}
           >
             <div className="flex justify-between items-center mb-2">
-            <div className="font-semibold">
+              <div className="font-semibold">
                 {session.lastMessage && session.lastMessage.length > 30 
                   ? `${session.lastMessage.substring(0, 30)}...` 
                   : session.lastMessage || '空對話'}
@@ -31,6 +76,18 @@ const ChatHistory = ({ historyMessages, loadSessionChat, setShowHistory }) => {
             </div>
           </div>
         ))}
+        
+        {isLoadingHistory && (
+          <div className="flex justify-center py-4">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-gray-900"></div>
+          </div>
+        )}
+        
+        {!hasMoreHistory && historyMessages.length > 0 && (
+          <div className="text-center text-gray-500 text-sm py-4">
+            沒有更多記錄了
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/ChatInterface/Header.jsx
+++ b/frontend/src/components/ChatInterface/Header.jsx
@@ -10,6 +10,15 @@ const Header = ({
   handleNewChat = () => {},
   fetchChatHistory = () => {}
 }) => {
+  const handleHistoryClick = () => {
+    setShowHistory(!showHistory);
+    // 只有在開啟歷史記錄且尚未載入數據時才載入
+    if (!showHistory) {
+      // 可以讓 ChatInterface 中的 useEffect 自動處理載入邏輯
+      // 不在這裡直接調用 fetchChatHistory
+    }
+  };
+
   return (
     <div className="bg-white shadow-sm p-4">
       <div className="max-w-4xl mx-auto flex justify-between items-center">
@@ -32,12 +41,7 @@ const Header = ({
           </button>
           <button 
             className={`p-2 rounded-full ${showHistory ? 'bg-blue-100' : 'hover:bg-gray-100'}`}
-            onClick={() => {
-              setShowHistory(!showHistory);
-              if (!showHistory) {
-                fetchChatHistory();
-              }
-            }}
+            onClick={handleHistoryClick}
           >
             <History className={`w-5 h-5 ${showHistory ? 'text-blue-600' : 'text-gray-600'}`} />
           </button>

--- a/frontend/src/components/ChatInterface/index.jsx
+++ b/frontend/src/components/ChatInterface/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Header from './Header';
 import ChatHistory from './ChatHistory';
 import MessageList from './MessageList';
@@ -14,6 +14,14 @@ const ChatInterface = () => {
   const messageHandlers = useMessageHandlers(chatState);
   const backendStatus = useBackendStatus();
   const vectorDB = useVectorDB(chatState.sessionId); // Instantiate the hook
+
+  // 當 showHistory 變為 true 時，載入歷史記錄
+  useEffect(() => {
+    if (chatState.showHistory && chatState.historyMessages.length === 0) {
+      // 只有當顯示歷史記錄且尚未加載數據時才載入
+      chatState.fetchChatHistory(0, false);
+    }
+  }, [chatState.showHistory, chatState.fetchChatHistory, chatState.historyMessages.length]);
 
   return (
     <div className="flex flex-col h-[100dvh] bg-gray-100">
@@ -32,6 +40,9 @@ const ChatInterface = () => {
           historyMessages={chatState.historyMessages}
           loadSessionChat={chatState.loadSessionChat}
           setShowHistory={chatState.setShowHistory}
+          loadMoreHistory={chatState.loadMoreHistory}
+          isLoadingHistory={chatState.isLoadingHistory}
+          hasMoreHistory={chatState.hasMoreHistory}
         />
       )}
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -86,7 +86,13 @@ export const chatService = {
       const response = await apiClient.get('/history', {
         params: { skip, limit },
       });
-      return response.data;
+      return {
+        items: response.data.items,
+        total: response.data.total,
+        page: response.data.page,
+        limit: response.data.limit,
+        hasMore: response.data.has_more
+      };
     } catch (error) {
       console.error('Error fetching chat history:', error);
       throw error;


### PR DESCRIPTION
- Added a pagination response model on the backend to return paginated chat history data.
- Updated the frontend to support infinite scroll loading for older history, including loading state indicators and "no more records" prompts.
- Optimized the history loading logic to ensure automatic data loading when displaying historical records.